### PR TITLE
feat(injectable): allow for blocking injection per vertex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Go](https://github.com/whitaker-io/machine/workflows/Go/badge.svg?branch=master)
 [![GoDoc](https://godoc.org/github.com/whitaker-io/machine?status.svg)](https://godoc.org/github.com/whitaker-io/machine)
+[![Go Report Card](https://goreportcard.com/badge/github.com/whitaker-io/machine)](https://goreportcard.com/report/github.com/whitaker-io/machine)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/aa8efa7beb3f4e66a5dc0247e25557b5)](https://www.codacy.com?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=whitaker-io/machine&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/aa8efa7beb3f4e66a5dc0247e25557b5)](https://www.codacy.com?utm_source=github.com&utm_medium=referral&utm_content=whitaker-io/machine&utm_campaign=Badge_Coverage)
 [![Gitter chat](https://badges.gitter.im/whitaker-io/machine.png)](https://gitter.im/whitaker-io/machine)

--- a/builder.go
+++ b/builder.go
@@ -75,6 +75,12 @@ func (m *builder) Inject(ctx context.Context, events map[string][]*Packet) {
 					packet.newSpan(ctx, v.metrics.tracer, v.vertexType+".inject", v.id, v.vertexType)
 				}
 			}
+
+			if !*v.option.Injectable {
+				m.recorder(v.id, v.vertexType, "injection-denied", payload)
+				continue
+			}
+
 			v.input.channel <- payload
 		}
 	}
@@ -361,6 +367,7 @@ func NewStream(id string, retriever Retriever, options ...*Option) Stream {
 			},
 		},
 		vertacies: map[string]*vertex{},
+		recorder:  func(s1, s2, s3 string, p []*Packet) {},
 	}
 
 	x.connector = func(ctx context.Context, b *builder) error {

--- a/builder_test.go
+++ b/builder_test.go
@@ -141,7 +141,7 @@ func Benchmark_Test_New(b *testing.B) {
 		return channel
 	},
 		&Option{FIFO: boolP(false)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(false)},
 		&Option{BufferSize: intP(0)},
@@ -190,7 +190,7 @@ func Test_New(b *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(false)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(false)},
 		&Option{BufferSize: intP(0)},
@@ -251,7 +251,7 @@ func Test_New2(b *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(true)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(true)},
 		&Option{BufferSize: intP(1000)},
@@ -333,7 +333,7 @@ func Test_Missing_Leaves(b *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(true)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(true)},
 		&Option{BufferSize: intP(1000)},
@@ -346,7 +346,7 @@ func Test_Missing_Leaves(b *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(true)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(true)},
 		&Option{BufferSize: intP(1000)},
@@ -357,7 +357,7 @@ func Test_Missing_Leaves(b *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(true)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(true)},
 		&Option{BufferSize: intP(1000)},
@@ -376,7 +376,7 @@ func Test_Missing_Leaves(b *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(true)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(true)},
 		&Option{BufferSize: intP(1000)},
@@ -391,7 +391,7 @@ func Test_Missing_Leaves(b *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(true)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(true)},
 		&Option{BufferSize: intP(1000)},
@@ -420,7 +420,7 @@ func Test_Missing_Leaves(b *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(true)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(true)},
 		&Option{BufferSize: intP(1000)},
@@ -486,7 +486,7 @@ func Test_Inject(b *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(false)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(true)},
 		&Option{BufferSize: intP(0)},
@@ -501,7 +501,7 @@ func Test_Inject(b *testing.T) {
 			return fmt.Errorf("error")
 		},
 			&Option{FIFO: boolP(false)},
-			&Option{Idempotent: boolP(true)},
+			&Option{Injectable: boolP(true)},
 			&Option{Metrics: boolP(true)},
 			&Option{Span: boolP(false)},
 			&Option{BufferSize: intP(0)},
@@ -513,7 +513,7 @@ func Test_Inject(b *testing.T) {
 			return d1
 		},
 			&Option{FIFO: boolP(false)},
-			&Option{Idempotent: boolP(true)},
+			&Option{Injectable: boolP(true)},
 			&Option{Metrics: boolP(true)},
 			&Option{Span: boolP(false)},
 			&Option{BufferSize: intP(0)}).
@@ -521,14 +521,14 @@ func Test_Inject(b *testing.T) {
 			return d1
 		},
 			&Option{FIFO: boolP(false)},
-			&Option{Idempotent: boolP(true)},
+			&Option{Injectable: boolP(true)},
 			&Option{Metrics: boolP(true)},
 			&Option{Span: boolP(false)},
 			&Option{BufferSize: intP(0)},
 		).
 		Fork("fork_id", ForkError,
 			&Option{FIFO: boolP(false)},
-			&Option{Idempotent: boolP(true)},
+			&Option{Injectable: boolP(true)},
 			&Option{Metrics: boolP(true)},
 			&Option{Span: boolP(false)},
 			&Option{BufferSize: intP(0)},
@@ -539,7 +539,7 @@ func Test_Inject(b *testing.T) {
 		return nil
 	},
 		&Option{FIFO: boolP(false)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(false)},
 		&Option{BufferSize: intP(0)},
@@ -585,7 +585,7 @@ func Test_Inject_Cancel(b *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(false)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(true)},
 		&Option{BufferSize: intP(0)},
@@ -658,7 +658,7 @@ func Test_Link(t *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(false)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(false)},
 		&Option{BufferSize: intP(0)},
@@ -680,7 +680,10 @@ func Test_Link(t *testing.T) {
 			}
 
 			return false
-		}).Handler)
+		}).Handler,
+			&Option{Injectable: boolP(false)},
+			&Option{BufferSize: intP(10)},
+		)
 
 	left.Transmit("sender_id", func(d []Data) error {
 		out <- d
@@ -705,15 +708,22 @@ func Test_Link(t *testing.T) {
 
 	go func() {
 		for n := 0; n < count; n++ {
+			out := []*Packet{}
+			buf := &bytes.Buffer{}
+			enc, dec := gob.NewEncoder(buf), gob.NewDecoder(buf)
+
+			_ = enc.Encode(testPayload)
+			_ = dec.Decode(&out)
 			m.Inject(context.Background(), map[string][]*Packet{
-				"map_id": testPayload,
+				"map_id":  out,
+				"fork_id": out,
 			})
 		}
 	}()
 
 	<-time.After(time.Second)
 	cancel()
-	<-time.After(3 * time.Second)
+	<-time.After(time.Second)
 }
 
 func Test_Link_not_ancestor(t *testing.T) {
@@ -729,7 +739,7 @@ func Test_Link_not_ancestor(t *testing.T) {
 		return channel
 	},
 		&Option{FIFO: boolP(false)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(false)},
 		&Option{BufferSize: intP(0)},
@@ -754,7 +764,7 @@ func Test_Link_not_ancestor(t *testing.T) {
 
 	left.Link("link_id", "sender_id",
 		&Option{FIFO: boolP(false)},
-		&Option{Idempotent: boolP(true)},
+		&Option{Injectable: boolP(true)},
 		&Option{Metrics: boolP(true)},
 		&Option{Span: boolP(true)},
 		&Option{BufferSize: intP(0)},

--- a/machine.go
+++ b/machine.go
@@ -141,7 +141,6 @@ func (r recorder) wrap(id, vertexType string, h handler) handler {
 	return func(payload []*Packet) {
 		r(id, vertexType, "start", payload)
 		h(payload)
-		r(id, vertexType, "done", payload)
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -51,7 +51,7 @@ var (
 
 	defaultOptions = &Option{
 		FIFO:       boolP(false),
-		Idempotent: boolP(false),
+		Injectable: boolP(true),
 		Metrics:    boolP(true),
 		Span:       boolP(true),
 		BufferSize: intP(0),
@@ -72,7 +72,7 @@ type Packet struct {
 // Option type for holding machine settings
 type Option struct {
 	FIFO       *bool
-	Idempotent *bool
+	Injectable *bool
 	BufferSize *int
 	Span       *bool
 	Metrics    *bool
@@ -142,7 +142,7 @@ func (o *Option) join(option *Option) *Option {
 	out := &Option{
 		FIFO:       o.FIFO,
 		BufferSize: o.BufferSize,
-		Idempotent: o.Idempotent,
+		Injectable: o.Injectable,
 		Metrics:    o.Metrics,
 		Span:       o.Span,
 	}
@@ -155,8 +155,8 @@ func (o *Option) join(option *Option) *Option {
 		out.BufferSize = option.BufferSize
 	}
 
-	if option.Idempotent != nil {
-		out.Idempotent = option.Idempotent
+	if option.Injectable != nil {
+		out.Injectable = option.Injectable
 	}
 
 	if option.Metrics != nil {


### PR DESCRIPTION
changing idempotent to injectable as a flag to block injection
adding default no-op recorder
adding go report card to readme